### PR TITLE
Upgrade conan

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -93,7 +93,7 @@ jobs:
             conan config install $conan_config --type git -sf remotes_public
             conan build -o "dds-fmu/*:with_doc=True" -b missing --update \
               -pr:b ${{ matrix.PROFILE }} -pr:h ${{ matrix.PROFILE }} -s build_type=${{ matrix.TYPE }} \
-              -c tools.build:jobs=2 -c tools.build:skip_test=$SKIP_TEST -b expat/*.
+              -c tools.build:jobs=2 -c tools.build:skip_test=$SKIP_TEST -b expat/* .
             if ([[ ${{ matrix.TYPE }} == "Release" ]]); then cp -r build/Release/docs/html public/; fi
 
         - name: Upload artifacts

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -74,7 +74,7 @@ jobs:
           id: conan
           uses: turtlebrowser/get-conan@main
           with:
-            version: 2.3.0
+            version: 2.22.1
 
         - name: Installing pre-requisites
           run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -57,7 +57,7 @@ jobs:
 
     linux:
       name: Linux build
-      runs-on: ubuntu-24.04
+      runs-on: ubuntu-22.04
       strategy:
           matrix:
             TYPE: [Debug, Release]

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -85,7 +85,7 @@ jobs:
             sudo apt update && sudo apt install -y openssh-client texlive-binaries perl
             if ([[ ${{ matrix.TYPE }} == "Debug" ]]); \
               then echo "SKIP_TEST=True" >> "$GITHUB_ENV"; \
-              else export "SKIP_TEST=False" >> "$GITHUB_ENV"; fi
+              else echo "SKIP_TEST=False" >> "$GITHUB_ENV"; fi
 
         - name: Conan build
           run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -27,7 +27,7 @@ jobs:
           id: conan
           uses: turtlebrowser/get-conan@main
           with:
-            version: 2.3.0
+            version: 2.22.1
 
         - name: Setting variables
           run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -31,7 +31,7 @@ jobs:
 
         - name: Setting variables
           run: |
-            if ("${{ matrix.TYPE }}" -like "Debug") { echo "SKIP_TEST=True" >> "$GITHUB_ENV" }
+            if ("${{ matrix.TYPE }}" -like "Debug") { echo "SKIP_TEST=True" >> $env:GITHUB_ENV }
 
         - name: Conan build
           run: |
@@ -53,7 +53,7 @@ jobs:
 
     linux:
       name: Linux build
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       strategy:
           matrix:
             TYPE: [Debug, Release]

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -82,7 +82,7 @@ jobs:
 
         - name: Installing pre-requisites
           run: |
-            sudo apt update && sudo apt install -y openssh-client texlive-binaries perl
+            sudo apt update && sudo apt install -y openssh-client texlive-binaries perl libbsd-dev
             if ([[ ${{ matrix.TYPE }} == "Debug" ]]); \
               then echo "SKIP_TEST=True" >> "$GITHUB_ENV"; \
               else echo "SKIP_TEST=False" >> "$GITHUB_ENV"; fi

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -32,9 +32,9 @@ jobs:
         - name: Setting variables
           run: |
             if ("${{ matrix.TYPE }}" -like "Debug") { 
-              echo "SKIP_TEST=True" >> $GITHUB_ENV 
+              echo "SKIP_TEST=True" >> $env:GITHUB_ENV 
             } else { 
-              echo "SKIP_TEST=False" >> $GITHUB_ENV 
+              echo "SKIP_TEST=False" >> $env:GITHUB_ENV 
             }
 
         - name: Conan build
@@ -43,7 +43,7 @@ jobs:
             conan config install "${{ env.conan_config }}" --type git -sf remotes_public
             conan build -o "dds-fmu/*:with_doc=False" -b missing --update `
               -pr:b ${{ matrix.PROFILE }} -pr:h ${{ matrix.PROFILE }} -s build_type=${{ matrix.TYPE }} `
-              -c tools.build:jobs=2 -c tools.build:skip_test=$SKIP_TEST .
+              -c tools.build:jobs=2 -c tools.build:skip_test=$env:SKIP_TEST .
 
         - name: Upload artifacts
           uses: actions/upload-artifact@v4

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -31,7 +31,11 @@ jobs:
 
         - name: Setting variables
           run: |
-            if ("${{ matrix.TYPE }}" -like "Debug") { echo "SKIP_TEST=True" >> $env:GITHUB_ENV }
+            if ("${{ matrix.TYPE }}" -like "Debug") { 
+              echo "SKIP_TEST=True" >> $GITHUB_ENV 
+            } else { 
+              echo "SKIP_TEST=False" >> $GITHUB_ENV 
+            }
 
         - name: Conan build
           run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -21,7 +21,7 @@ jobs:
           with:
             path: |
               ~/.conan2
-            key: ${{ runner.os }}-${{ matrix.TYPE }}-dds-fmu
+            key: ${{ runner.os }}-${{ matrix.TYPE }}-dds-fmu-${{ hashFiles('**/conanfile.py') }}
 
         - name: Install Conan
           id: conan
@@ -72,7 +72,7 @@ jobs:
           with:
             path: |
               ~/.conan2
-            key: ${{ env.TARGET }}-dds-fmu
+            key: ${{ runner.os }}-${{ matrix.TYPE }}-dds-fmu-${{ hashFiles('**/conanfile.py') }}
 
         - name: Install Conan
           id: conan

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -93,7 +93,7 @@ jobs:
             conan config install $conan_config --type git -sf remotes_public
             conan build -o "dds-fmu/*:with_doc=True" -b missing --update \
               -pr:b ${{ matrix.PROFILE }} -pr:h ${{ matrix.PROFILE }} -s build_type=${{ matrix.TYPE }} \
-              -c tools.build:jobs=2 -c tools.build:skip_test=$SKIP_TEST .
+              -c tools.build:jobs=2 -c tools.build:skip_test=$SKIP_TEST -b expat/*.
             if ([[ ${{ matrix.TYPE }} == "Release" ]]); then cp -r build/Release/docs/html public/; fi
 
         - name: Upload artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,9 @@ add_library(configuration OBJECT
   "${CMAKE_SOURCE_DIR}/src/configuration/model-descriptor.cpp"
   )
 
-target_compile_options(configuration PRIVATE /bigobj)
+if (MSVC)
+  target_compile_options(configuration PRIVATE /bigobj)
+endif()
 
 target_link_libraries(configuration
   PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ add_library(configuration OBJECT
   "${CMAKE_SOURCE_DIR}/src/configuration/model-descriptor.cpp"
   )
 
+target_compile_options(configuration PRIVATE /bigobj)
+
 target_link_libraries(configuration
   PUBLIC
   eprosima::xtypes

--- a/tests/keyed_members.cpp
+++ b/tests/keyed_members.cpp
@@ -18,6 +18,7 @@ protected:
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     if (pub) { delete pub; }
     if (sub) { delete sub; }
+    ddsfmu::Converter::clear_data_structures();
   }
   void Init(Permutation creator_pub, Permutation creator_sub) {
     pub = new HelloPubSub(creator_pub, true);

--- a/tests/pubsub_procedure.cpp
+++ b/tests/pubsub_procedure.cpp
@@ -256,4 +256,5 @@ TEST(PubSub, UsageProcedure) {
 
   participant->delete_topic(topic);
   eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(participant);
+  ddsfmu::Converter::clear_data_structures();
 }

--- a/tests/xtypes.cpp
+++ b/tests/xtypes.cpp
@@ -65,6 +65,7 @@ TEST(XTypes, BasicUsage) {
   // nested
   my_space["universe"][0]["my_inner"]["my_uint32"] = 23u;
   my_space["universe"][1]["my_inner"]["my_uint32"] = 24u;
+  ddsfmu::Converter::clear_data_structures();
 }
 
 TEST(XTypes, Annotations) {
@@ -101,6 +102,7 @@ TEST(XTypes, Annotations) {
     << "my_uint32 is @key"; // false, true
   EXPECT_EQ(inner.member(1).is_optional(), inner2.member(1).is_optional())
     << "yes is @optional"; // false, true
+  ddsfmu::Converter::clear_data_structures();
 }
 
 
@@ -171,6 +173,7 @@ TEST(XTypes, DdsEnum) {
   ASSERT_NE(participant, nullptr);
 
   participant->register_type(dyntype_sup);
+  ddsfmu::Converter::clear_data_structures();
 }
 
 
@@ -193,4 +196,5 @@ TEST(XTypes, FloatingTypes) {
   context = eprosima::xtypes::idl::parse(my_idl, context);
   EXPECT_TRUE(context.success) << "IDL parsing successful";
 
+  ddsfmu::Converter::clear_data_structures();
 }


### PR DESCRIPTION
- Upgraded conan to 3.22.1
- Fixed Segmentation Fault during tests on windows Release by adding `ddsfmu::Converter::clear_data_structures()` at the end of tests that uses dynamic types
